### PR TITLE
Center .signature-icon

### DIFF
--- a/signature.html
+++ b/signature.html
@@ -82,6 +82,9 @@
       .signature-icon {
         color: #4f3b91;
         margin-right: 5px;
+        text-align: center;
+        width: 1rem;
+        display: inline-block;
       }
 
       .ribbon {


### PR DESCRIPTION
Make .signature-icon a fixed width so the text next to it lines up, and center the icon